### PR TITLE
Fixed index out of bound in Rust SegmentTree

### DIFF
--- a/rust/src/generic.rs
+++ b/rust/src/generic.rs
@@ -52,7 +52,7 @@ where
         let j = match range.end_bound() {
             Bound::Included(&j) => j,
             Bound::Excluded(&j) => j - 1,
-            Bound::Unbounded => self.arr.len() - 1,
+            Bound::Unbounded => self.n - 1,
         };
 
         self.f(1, 0, self.n - 1, i, j)


### PR DESCRIPTION
`self.arr.len() - 1` is `2  * self.n - 1` but we in fact only have `self.n - 1` elements. This can cause index out of bound when using unbounded end bound.